### PR TITLE
Add the capacity to recurse among default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ It is possible to use environment values in order to set default values for para
 
 In the example above, the following line used the `USER` environment variable as a default value:
 
+### Multiple defaults for a parameter
+It is also possible to have multiple default values (eg `{{QUESTION|DEFAULT1|DEFAULT2}}`.
+This can be useful if you want to use environment variables as a default and, in case the environment variable is not set, fall back to a hardcoded default value.
+
+Hence, you can write in your dis file for instance:
+```yaml
+myVar: {{"My var []?|=ENV[MY_VAR]|my_default_var}}
+```
+
+If the MY_VAR environment variable is set to 'foobar', the question will be:
+```
+My var [foobar]?
+```
+
+If the MY_VAR environment variable is not set, the question will be:
+```
+My var [my_default_var]?
+```
+
+### Non-interactive mode
+When composer is launched with `--no-interaction` option, the default value is applied.
+This can be a good option for deployment process, in case you use environment variables in your dist file.
+
 # LICENSE
 See `LICENSE.txt` file in this same package.
 

--- a/src/Processor/Generic.php
+++ b/src/Processor/Generic.php
@@ -143,15 +143,18 @@ class Generic implements ProcessorInterface
         if (count($matches) > 1) {
             $explode = explode('|', $matches[1]);
             $question = $explode[0];
-            $default = @$explode[1] ?: null;
-            // if default syntax is =ENV[VARIABLE_NAME] then extract VARIABLE_NAME from the environment as default value
-            if (strpos($default, '=ENV[') === 0) {
-                $envMatch = [];
-                preg_match('/^\=ENV\[(.*)\]$/', $default, $envMatch);
-                if (isset($envMatch[1])) {
-                    $default = $this->_getEnvValue($envMatch[1]);
+            $index = 0;
+            do {
+                $default = @$explode[++$index] ?: null;
+                // if default syntax is =ENV[VARIABLE_NAME] then extract VARIABLE_NAME from the environment as default value
+                if (strpos($default, '=ENV[') === 0) {
+                    $envMatch = [];
+                    preg_match('/^\=ENV\[(.*)\]$/', $default, $envMatch);
+                    if (isset($envMatch[1])) {
+                        $default = $this->_getEnvValue($envMatch[1]);
+                    }
                 }
-            }
+            } while( empty($default) && $index < count($explode) );
             $question = str_replace('[]', "[$default]", $question);
             $result = $this->getIO()->ask(rtrim($question) . ' ', $default);
         }

--- a/test/Processor/GenericTest.php
+++ b/test/Processor/GenericTest.php
@@ -40,6 +40,11 @@ class GenericTest extends TestCase
     const TEST_UNMAPPED_ENV_KEY = 'CUBE_TEST_UNMAPPED';
     const TEST_UNMAPPED_ENV_VAL = 'UNMAPPED_VALUE';
 
+    // used to test not existing env variables
+    const TEST_UNKNOWN_ENV_KEY = 'UNKNOWN_ENV_KEY';
+    const TEST_UNKNOWN_ENV_KEY2 = 'UNKNOWN_ENV_KEY2';
+
+
     protected $environmentBackup = [];
 
 
@@ -295,12 +300,19 @@ class GenericTest extends TestCase
     public function templateReplaceProvider()
     {
         $envKey = self::TEST_MAPPED_ENV_KEY;
+        $unknownEnvKey = self::TEST_UNKNOWN_ENV_KEY;
+        $unknownEnvKey2 = self::TEST_UNKNOWN_ENV_KEY2;
+
         return [
             [['test'], null, 'test'],
             [['{{ }}', ' '], ' ', null],
             [['{{username}}', 'username'], 'username', null],
             [['{{username|john.doe}}', 'username|john.doe'], 'username', 'john.doe'],
             [["{{environment|=ENV[$envKey]}}", "environment|=ENV[$envKey]"], 'environment', self::TEST_ENV_VAL],
+            [["{{environment|=ENV[$envKey]|localhost}}", "environment|=ENV[$envKey]|localhost"], 'environment', self::TEST_ENV_VAL],
+            [["{{environment|=ENV[$unknownEnvKey]|localhost}}", "environment|=ENV[$unknownEnvKey]|localhost"], 'environment', 'localhost'],
+            [["{{environment|=ENV[$unknownEnvKey]|=ENV[$envKey]|localhost}}", "environment|=ENV[$unknownEnvKey]|=ENV[$envKey]|localhost"], 'environment', self::TEST_ENV_VAL],
+            [["{{environment|=ENV[$unknownEnvKey]|=ENV[$unknownEnvKey2]|localhost}}", "environment|=ENV[$unknownEnvKey]|=ENV[$unknownEnvKey2]|localhost"], 'environment', 'localhost'],
         ];
     }
 


### PR DESCRIPTION
Instead of having only one default value possible in the template (eg `{{Question|default}}`), this PR add the ability to chain multiple default values.

This can be useful to use env variables as a first default if available and, if not, fall back to a string.
eg:

```
{{My param []?|=ENV[MY_PARAM_ENV]|default}}
```

If MY_PARAM_ENV variable is set, use it as default, else use "default" hardcoded string.

In a deployment process, as a non-interactive execution, you can have you secrets set as env variables (and fall back to default values if not set).
