### PR TITLE
Readme, ambiguous dist file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following into your root `composer.json` file:
     },
     "extra": {
         "dist-installer-params": {
-            "file": "config/autoload/database.config.php.dist"
+            "file": "config/autoload/database.config.php"
         }
     }
 }


### PR DESCRIPTION
Is `file` parameter should not be the real file, and not the .dist file ?
